### PR TITLE
RUN-5196 Google Fonts errors on https docs sites

### DIFF
--- a/static/styles/jsdoc-default.css
+++ b/static/styles/jsdoc-default.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Roboto);
+@import url(https://fonts.googleapis.com/css?family=Roboto);
 
 html
 {


### PR DESCRIPTION
This fixes the `Mixed Content` problem where a page loaded over `https://` requests an `http://` resource.