### PR TITLE
RUN-5203 adds support for custom tags

### DIFF
--- a/static/styles/custom.css
+++ b/static/styles/custom.css
@@ -1,0 +1,24 @@
+article dl {
+  margin-bottom: 60px;
+}
+
+dl.details {
+  margin-bottom: 0px;
+  margin-top: 0px;
+}
+
+.custom-tag {
+  border-radius: 5px;
+  border-style: solid;
+  border-width: 1px;
+  display: inline-block;
+  font-family: Consolas, Monaco, 'Roboto', monospace;
+  font-size: 12px;
+  padding: 1px 5px;
+}
+
+.custom-tag.experimental {
+  background: #fff2e8;
+  border-color: #ffbb96;
+  color: #fa541c;
+}

--- a/tmpl/custom-tags.tmpl
+++ b/tmpl/custom-tags.tmpl
@@ -1,0 +1,11 @@
+<?js
+  var tags = obj
+?>
+
+<?js tags.forEach(function(tag) { ?>
+
+  <?js if (tag.title === 'experimental') { ?>
+    <div class="custom-tag experimental">EXPERIMENTAL</div>
+  <?js } ?>
+
+<?js }); ?>

--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -21,6 +21,7 @@
     <![endif]-->
     <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
     <link type="text/css" rel="stylesheet" href="styles/jsdoc-default.css">
+    <link type="text/css" rel="stylesheet" href="styles/custom.css">
 </head>
 
 <body>

--- a/tmpl/method.tmpl
+++ b/tmpl/method.tmpl
@@ -15,6 +15,12 @@ var self = this;
     <?js } ?>
 <?js } ?>
 
+<?js if (data.tags && tags.length) { ?>
+    <div class="custom-tags">
+        <?js= self.partial('custom-tags.tmpl', tags) ?>
+    </div>
+<?js } ?>
+
 <?js if (data.kind !== 'module' && data.description) { ?>
 <div class="description">
     <?js= data.description ?>


### PR DESCRIPTION
Adding `@experimental` tag will add an experimental label to the documentation like so:

![image](https://user-images.githubusercontent.com/5790216/56591771-5621ff80-65b7-11e9-901f-ef85b6c73dcb.png)
